### PR TITLE
feat: cargamos namespace webfeeds solo cuando sea neceasario

### DIFF
--- a/src/Entities/Item.php
+++ b/src/Entities/Item.php
@@ -26,6 +26,14 @@ class Item
     /**
      * @var string|null
      *
+     * @Serializer\XmlElement(namespace="http://purl.org/rss/1.0/modules/content/")
+     * @Serializer\SerializedName("encoded")
+     */
+    private $contentEncoded;
+
+    /**
+     * @var string|null
+     *
      * @Serializer\XmlElement(namespace="http://purl.org/dc/elements/1.1/")
      * @Serializer\SerializedName("creator")
      */
@@ -87,13 +95,6 @@ class Item
      */
     private $mediaCredit;
 
-    /**
-     * @var string|null
-     *
-     * @Serializer\XmlElement(namespace="http://purl.org/rss/1.0/modules/content/")
-     * @Serializer\SerializedName("encoded")
-     */
-    private $contentEncoded;
 
     public function getTitle(): ?string
     {
@@ -125,6 +126,17 @@ class Item
     public function setDescription(?string $description): Item
     {
         $this->description = $description;
+        return $this;
+    }
+
+    public function getContentEncoded(): ?string
+    {
+        return $this->contentEncoded;
+    }
+
+    public function setContentEncoded(?string $contentEncoded): Item
+    {
+        $this->contentEncoded = $contentEncoded;
         return $this;
     }
 
@@ -235,17 +247,6 @@ class Item
     public function setMediaCredit(?string $mediaCredit): Item
     {
         $this->mediaCredit = $mediaCredit;
-        return $this;
-    }
-
-    public function getContentEncoded(): ?string
-    {
-        return $this->contentEncoded;
-    }
-
-    public function setContentEncoded(?string $contentEncoded): Item
-    {
-        $this->contentEncoded = $contentEncoded;
         return $this;
     }
 

--- a/src/Services/RssWriter.php
+++ b/src/Services/RssWriter.php
@@ -24,6 +24,27 @@ class RssWriter
         );
         $serializer = $serializerBuilder->build();
         $xml = $serializer->serialize($rss, "xml");
+        $xml = $this->removeUnusedNamespaces($rss, $xml);
+        return $xml;
+    }
+
+    /**
+     * Eliminamos namespace si no se está indicando Icon.
+     * Eso lo hacemos no cargar ese namespace si no estrictamente necesario y
+     * evitar el warning "Use of unknown namespace: http://webfeeds.org/rss/1.0"
+     *
+     * @param RssInterface $rss
+     * @param string $xml
+     * @return string
+     */
+    private function removeUnusedNamespaces(RssInterface $rss, string $xml): string
+    {
+        if (is_null($rss->getChannel()->getIcon())) {
+            $namespacePrefixToRemove = "webfeeds";
+            // Usar expresión regular para eliminar el atributo de namespace específico
+            $namespaceAttrPattern = '/xmlns:' . preg_quote($namespacePrefixToRemove, '/') . '="[^"]*"/';
+            $xml = preg_replace($namespaceAttrPattern, '', $xml);
+        }
         return $xml;
     }
 }


### PR DESCRIPTION
Previamente se añadió el namespace webfeeds para poder añadir el campo webfeeds:icon

Para evitar el warning que indica el validador de W3C Feed, solo añadiremos el namespace solo cuando sea estrictamente necesario, es decir, cuando se haya añadido el campo webfeeds:icon en el RSS.

Se ha cambiado el orden en el que se muestra content:encoded para cumplir con el standard, se mostrará después de "description"