### PR TITLE
feat: Ajustamos media content para todos los casos posibles

### DIFF
--- a/src/Entities/Google/Channel.php
+++ b/src/Entities/Google/Channel.php
@@ -27,14 +27,14 @@ class Channel implements ChannelInterface
      */
     private $link;
 
+    /** @var string|null */
+    private $description;
+
     /**
      * @var string|null
      *
      * @Serializer\XmlElement(cdata=false)
      */
-    private $description;
-
-    /** @var string|null */
     private $language;
 
     /**

--- a/src/Entities/MediaContent.php
+++ b/src/Entities/MediaContent.php
@@ -45,6 +45,69 @@ class MediaContent
      */
     private $height;
 
+    /**
+     * @var string|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $medium;
+
+    /**
+     * @var bool|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $isDefault;
+
+    /**
+     * @var string|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $expression;
+
+    /**
+     * @var int|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $bitrate;
+
+    /**
+     * @var int|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $framerate;
+
+    /**
+     * @var float|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $samplingrate;
+
+    /**
+     * @var int|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $channels;
+
+    /**
+     * @var int|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $duration;
+
+    /**
+     * @var string|null
+     *
+     * @Serializer\XmlAttribute()
+     */
+    private $lang;
+
     public function getUrl(): ?string
     {
         return $this->url;
@@ -97,6 +160,105 @@ class MediaContent
     public function setHeight(?int $height): MediaContent
     {
         $this->height = $height;
+        return $this;
+    }
+
+    public function getMedium(): ?string
+    {
+        return $this->medium;
+    }
+
+    public function setMedium(?string $medium): self
+    {
+        $this->medium = $medium;
+        return $this;
+    }
+
+    public function getIsDefault(): ?bool
+    {
+        return $this->isDefault;
+    }
+
+    public function setIsDefault(?bool $isDefault): self
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    public function getExpression(): ?string
+    {
+        return $this->expression;
+    }
+
+    public function setExpression(?string $expression): self
+    {
+        $this->expression = $expression;
+        return $this;
+    }
+
+    public function getBitrate(): ?int
+    {
+        return $this->bitrate;
+    }
+
+    public function setBitrate(?int $bitrate): self
+    {
+        $this->bitrate = $bitrate;
+        return $this;
+    }
+
+    public function getFramerate(): ?int
+    {
+        return $this->framerate;
+    }
+
+    public function setFramerate(?int $framerate): self
+    {
+        $this->framerate = $framerate;
+        return $this;
+    }
+
+    public function getSamplingrate(): ?float
+    {
+        return $this->samplingrate;
+    }
+
+    public function setSamplingrate(?float $samplingrate): self
+    {
+        $this->samplingrate = $samplingrate;
+        return $this;
+    }
+
+    public function getChannels(): ?int
+    {
+        return $this->channels;
+    }
+
+    public function setChannels(?int $channels): self
+    {
+        $this->channels = $channels;
+        return $this;
+    }
+
+    public function getDuration(): ?int
+    {
+        return $this->duration;
+    }
+
+    public function setDuration(?int $duration): self
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    public function getLang(): ?string
+    {
+        return $this->lang;
+    }
+
+    public function setLang(?string $lang): self
+    {
+        $this->lang = $lang;
         return $this;
     }
 


### PR DESCRIPTION
Se añaden nuevos tipos a `media:content` para que se pueda aplicar en todos los [casos](https://www.rssboard.org/media-rss#media-content), al igual que se ajusta para GoogleNewsShowcase